### PR TITLE
universal5420: sepolicy: additional fixes for chagallwifi

### DIFF
--- a/ramdisk/etc/ueventd.universal5420.rc
+++ b/ramdisk/etc/ueventd.universal5420.rc
@@ -26,7 +26,7 @@
 /dev/video37              0660   media      camera
 
 # scalers
-/dev/video50              0660   media      graphics
+/dev/video50              0660   mediacodec drmpc
 /dev/video51              0660   media      graphics
 /dev/video52              0660   media      graphics
 

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -178,6 +178,7 @@
 /sys/devices/platform/dw_mmc\.[0-9]+/mmc_host/mmc[0-9]+/mmc[0-9]+:[0-9]+/block/mmcblk[0-9]+/queue(/.*)?   u:object_r:sysfs_io_sched_tuneable:s0
 
 # Button
+/sys/devices/platform/i2c-gpio\.9/i2c-9/9-0060/input/input9(/.*)?        u:object_r:sysfs_homebutton_writable:s0
 /sys/devices/platform/i2c-gpio\.12/i2c-12/12-0020/input/input11(/.*)?    u:object_r:sysfs_homebutton_writable:s0
 
 # Camera
@@ -209,6 +210,7 @@
 # Lights
 /sys/devices/platform/s5p-mipi-dsim\.[0-9]+/backlight/panel(/.*)?    u:object_r:sysfs_backlight_writable:s0
 /sys/devices/virtual/sec/sec_touchkey/brightness        u:object_r:sysfs_sec_touchkey:s0
+/sys/class/sec/sec_touchkey/input/enabled               u:object_r:sysfs_touchscreen_writable:s0
 /sys/class/leds(/.*)?                                   u:object_r:sysfs_leds:s0
 /sys/class/lcd/panel/power_reduce                       u:object_r:sysfs_graphics:s0
 
@@ -243,6 +245,7 @@
 /sys/power/wake_unlock     u:object_r:sysfs_power:s0
 /sys/power/wakeup_count    u:object_r:sysfs_power:s0
 /sys/devices/platform/s3c2440-i2c\.[0-9]+/i2c-[0-9]+/[0-9]+-[0-9]+/input/input2(/.*)?    u:object_r:sysfs_power_writable:s0
+/sys/devices/platform/s3c64xx-spi\.[0-9]+/spi_master/spi2/spi2\.[0-9]+/arizona-extcon/input/input10(/.*)?    u:object_r:sysfs_power_writable:s0
 /sys/devices/platform/s3c64xx-spi\.[0-9]+/spi_master/spi2/spi2\.[0-9]+/arizona-extcon/input/input12(/.*)?    u:object_r:sysfs_power_writable:s0
 
 # Sensors
@@ -261,7 +264,8 @@
 /sys/devices/virtual/sec/tsp/cmd_list    u:object_r:sysfs_sec_touchscreen:s0
 
 # Touchkeys
-/sys/devices/platform/gpio-keys.0/input/input10(/.*)?     u:object_r:sysfs_sec_touchkey:s0
+/sys/devices/platform/gpio-keys\.0/input/input10(/.*)?     u:object_r:sysfs_sec_touchkey:s0
+/sys/devices/platform/gpio-keys\.0/input/input8(/.*)?      u:object_r:sysfs_sec_touchkey:s0
 /sys/devices/platform/i2c-gpio\.[0-9]+/i2c-[0-9]+/[0-9]+-[0-9]+/input/input11(/.*)? u:object_r:sysfs_sec_touchkey:s0
 
 # Usb

--- a/sepolicy/vendor/hal_wifi_default.te
+++ b/sepolicy/vendor/hal_wifi_default.te
@@ -1,9 +1,7 @@
 # hal_wifi_default.te
 
-allow hal_wifi_default efs_file:dir search;
 allow hal_wifi_default wifi_efs_file:dir search;
-
-allow hal_wifi_default efs_file:file r_file_perms;
+allow hal_wifi_default wifi_efs_file:file r_file_perms;
 
 allow hal_wifi_default wifi_data_file:file rw_file_perms;
 

--- a/sepolicy/vendor/hal_wifi_default.te
+++ b/sepolicy/vendor/hal_wifi_default.te
@@ -1,6 +1,7 @@
 # hal_wifi_default.te
 
 allow hal_wifi_default efs_file:dir search;
+allow hal_wifi_default wifi_efs_file:dir search;
 
 allow hal_wifi_default efs_file:file r_file_perms;
 

--- a/sepolicy/vendor/vendor_init.te
+++ b/sepolicy/vendor/vendor_init.te
@@ -11,12 +11,14 @@ allow vendor_init {
 allow vendor_init anr_data_file:dir getattr;
 
 allow vendor_init {
+    bluetooth_data_file
     media_rw_data_file
     wifi_data_file
 }:file setattr;
 
 allow vendor_init {
     apk_data_file
+    bluetooth_data_file
     gps_data_file
     mobicore_data_file
     nfc_data_file


### PR DESCRIPTION
Partly reported by Elim Garak.

```
avc: denied { open } for name="u:object_r:apexd_prop:s0" dev="tmpfs" ino=3102 scontext=u:r:flags_health_check:s0 tcontext=u:object_r:apexd_prop:s0 tclass=file permissive=1

avc: denied { read } for name=".mac.info" dev="mmcblk0p3" ino=22 scontext=u:r:hal_wifi_default:s0 tcontext=u:object_r:wifi_efs_file:s0 tclass=file permissive=1

avc: denied { search } for name="bluetooth" dev="mmcblk0p3" ino=21 context=u:r:vendor_init:s0 tcontext=u:object_r:bluetooth_data_file:s0 tclass=dir permissive=1

avc: denied { setattr } for name="bt_addr" dev="mmcblk0p3" ino=38 scontext=u:r:vendor_init:s0 tcontext=u:object_r:bluetooth_data_file:s0 tclass=file permissive=1
```

The only ones I am seeing now are:

```
#============= crash_dump ==============
allow crash_dump rootfs:dir read;

#============= init ==============
allow init kernel:system module_request;

#============= netd ==============
allow netd kernel:system module_request;

#============= system_server ==============
allow system_server unlabeled:file unlink;
```

The unlabeled file for system_server is log.gz:
```
avc: denied { unlink } for name="log.gz" dev="mmcblk0p19" ino=6403 scontext=u:r:system_server:s0 tcontext=u:object_r:unlabeled:s0 tclass=file permissive=1
```
which I guess is `/cache/recovery/log.gz`, should that one be labeled?