### PR TITLE
fix bluetooth crash

### DIFF
--- a/sepolicy/vendor/hal_bluetooth_default.te
+++ b/sepolicy/vendor/hal_bluetooth_default.te
@@ -3,3 +3,7 @@
 allow hal_bluetooth_default gps_device:chr_file rw_file_perms;
 
 allow hal_bluetooth_default efs_file:file r_file_perms;
+
+allow hal_bluetooth_default bluetooth_data_file:dir search;
+
+allow hal_bluetooth_default bluetooth_data_file:file { open read };


### PR DESCRIPTION
03-21 21:12:58.572  2927  2927 W HwBinder:2906_1: type=1400 audit(0.0:80): avc: denied { search } for name="bluetooth" dev="mmcblk0p3" ino=21 scontext=u:r:hal_bluetooth_default:s0 tcontext=u:object_r:bluetooth_data_file:s0 tclass=dir permissive=0