### PR TITLE
fix for MediaCodecsXmlParser

### DIFF
--- a/configs/media/media_codecs.xml
+++ b/configs/media/media_codecs.xml
@@ -111,19 +111,28 @@ Only the three quirks included above are recognized at this point:
             <Feature name="adaptive-playback" />
         </MediaCodec>
         <MediaCodec name="OMX.Exynos.vc1.dec" >
-            <Type name="video/wvc1" />
-            <Type name="video/x-ms-wmv" />
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
             <Quirk name="decoder-ignores-streamcorrupt-error" />
             <Quirk name="video-controller-check-enable" />
-            <Limit name="size" min="32x32" max="1920x1088" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="489600" />
-            <Limit name="bitrate" range="1-80000000" />
-            <Limit name="concurrent-instances" max="16"/>
-            <Feature name="adaptive-playback" />
+            <Type name="video/wvc1" >
+                <Limit name="size" min="32x32" max="1920x1088" />
+                <Limit name="alignment" value="2x2" />
+                <Limit name="block-size" value="16x16" />
+                <Limit name="blocks-per-second" min="1" max="489600" />
+                <Limit name="bitrate" range="1-80000000" />
+                <Limit name="concurrent-instances" max="16"/>
+                <Feature name="adaptive-playback" />
+            </Type>
+            <Type name="video/x-ms-wmv" >
+                <Limit name="size" min="32x32" max="1920x1088" />
+                <Limit name="alignment" value="2x2" />
+                <Limit name="block-size" value="16x16" />
+                <Limit name="blocks-per-second" min="1" max="489600" />
+                <Limit name="bitrate" range="1-80000000" />
+                <Limit name="concurrent-instances" max="16"/>
+                <Feature name="adaptive-playback" />
+            </Type>
         </MediaCodec>
         <MediaCodec name="OMX.Exynos.vp8.dec" type="video/x-vnd.on2.vp8" >
             <Quirk name="requires-allocate-on-input-ports" />


### PR DESCRIPTION
03-07 21:33:26.917  2995  2995 D MediaCodecsXmlParser: ignoring Limit specified outside of a Type at line 120 of /vendor/etc/media_codecs.xml
03-07 21:33:26.917  2995  2995 D MediaCodecsXmlParser: ignoring Limit specified outside of a Type at line 121 of /vendor/etc/media_codecs.xml
03-07 21:33:26.917  2995  2995 D MediaCodecsXmlParser: ignoring Limit specified outside of a Type at line 122 of /vendor/etc/media_codecs.xml
03-07 21:33:26.917  2995  2995 D MediaCodecsXmlParser: ignoring Limit specified outside of a Type at line 123 of /vendor/etc/media_codecs.xml
03-07 21:33:26.917  2995  2995 D MediaCodecsXmlParser: ignoring Limit specified outside of a Type at line 124 of /vendor/etc/media_codecs.xml
03-07 21:33:26.917  2995  2995 D MediaCodecsXmlParser: ignoring Limit specified outside of a Type at line 125 of /vendor/etc/media_codecs.xml
03-07 21:33:26.917  2995  2995 D MediaCodecsXmlParser: ignoring Feature specified outside of a Type at line 126 of /vendor/etc/media_codecs.xml
03-07 21:33:27.055  2995  2995 E MediaCodecsXmlParser: Cannot find the role for a decoder of type video/wvc1
03-07 21:33:27.055  2995  2995 E MediaCodecsXmlParser: Cannot find the role for a decoder of type video/x-ms-wmv