### PR TITLE
universal5420: extract mali blob from A800S ROM

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -69,6 +69,12 @@ extract "${MY_DIR}/proprietary-files.txt" "${SRC}" \
 BLOB_ROOT="$LINEAGE_ROOT"/vendor/"$VENDOR"/"$DEVICE_COMMON"/proprietary
 sed -i 's|EGL_KHR_surfaceless_context|EGL_HAX_surfaceless_context|g' $BLOB_ROOT/vendor/lib/egl/libGLES_mali.so
 
+# Ignore HW revision check error by changing a "bne" instruction into "beq"
+hexdump -ve '1/1 "%.2X"' $BLOB_ROOT/vendor/lib/egl/libGLES_mali.so | \
+        sed "s/0A20A0E1F33401EB000050E30500001A/0A20A0E1F33401EB000050E30500000A/g" | \
+        xxd -r -p > $BLOB_ROOT/vendor/lib/egl/libGLES_mali.so.patched
+mv $BLOB_ROOT/vendor/lib/egl/libGLES_mali.so.patched $BLOB_ROOT/vendor/lib/egl/libGLES_mali.so
+
 # Update trustlets location
 sed -i 's|system/app|vendor/app|g' $BLOB_ROOT/vendor/bin/mcDriverDaemon
 

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -14,8 +14,8 @@ vendor/firmware/bcm4350_V0301.0609.hcd|e6850eace7336e7390d53e7d9f47cc008f3c18f6
 lib/libexynoscamera.so:vendor/lib/libexynoscamera.so
 lib/libvdis.so:vendor/lib/libvdis.so
 
-# Graphics
-vendor/lib/egl/libGLES_mali.so
+# Graphics - libGLES_mali.so is taken from A800SKSS1CTJ1
+vendor/lib/egl/libGLES_mali.so|e39818113e5c3aa5b2998be6ec1375a778701775
 lib/libGLES_trace.so:vendor/lib/libGLES_trace.so
 # libw is a local libm compile of LineageOS/android_bionic@40e6fdba0 with 269025 applied on top
 vendor/lib/libw.so|14b82a29223980532b54739c2b94c318e2675515


### PR DESCRIPTION
And patch it so that it does not error due to being built for another HW revision of the mali blob.